### PR TITLE
Remove mb_convert_encoding() for HTML entities

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -245,21 +245,11 @@ class Transformer
         );
         $libxml_previous_state = libxml_use_internal_errors(true);
         $document = new \DOMDocument('1.0');
-        if (function_exists('mb_convert_encoding')) {
-            $document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', $encoding));
-        } else {
-            $this->addLog(
-                TransformerLog::DEBUG,
-                'Your content encoding is "' . $encoding . '" ' .
-                'but your PHP environment does not have mbstring. Trying to load your content with using meta tags.'
-            );
-            // wrap the content with charset meta tags
-            $document->loadHTML(
-                '<html><head>' .
-                '<meta http-equiv="Content-Type" content="text/html; charset=' . $encoding . '">' .
-                '</head><body>' . $content . '</body></html>'
-            );
-        }
+        $document->loadHTML(
+            '<html><head>' .
+            '<meta http-equiv="Content-Type" content="text/html; charset=' . $encoding . '">' .
+            '</head><body>' . htmlentities( $content, ENT_NOQUOTES ) . '</body></html>'
+        );
         libxml_clear_errors();
         libxml_use_internal_errors($libxml_previous_state);
         $result = $this->transform($context, $document);


### PR DESCRIPTION
PHP 8.2 generates a deprecation notice (as seen [here](https://github.com/Automattic/fb-instant-articles/actions/runs/3142782212/jobs/5106779427#step:10:50)):

> mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead

So this removes the use of the function and uses the existing fallback, albeit with use of `htmlentities()` as well.

This PR is potentially a significant change, so hopefully, the tests catch if something is now different.

Feedback and review highly encouraged as I don't feel 100% confident that this is the right change to resolve this. Maybe not adding the `htmlentities()` call would be better?

Background: https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html


