### PR TITLE
Revert and fix transformation

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -246,7 +246,7 @@ class Transformer
         $libxml_previous_state = libxml_use_internal_errors(true);
         $document = new \DOMDocument('1.0');
         if (function_exists('mb_convert_encoding')) {
-            $document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', $encoding));
+            $document->loadHTML(htmlspecialchars_decode(htmlentities(mb_convert_encoding($content, 'UTF-8', $encoding), ENT_NOQUOTES)));
         } else {
             $this->addLog(
                 TransformerLog::DEBUG,

--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -245,11 +245,21 @@ class Transformer
         );
         $libxml_previous_state = libxml_use_internal_errors(true);
         $document = new \DOMDocument('1.0');
-        $document->loadHTML(
-            '<html><head>' .
-            '<meta http-equiv="Content-Type" content="text/html; charset=' . $encoding . '">' .
-            '</head><body>' . htmlentities( $content, ENT_NOQUOTES ) . '</body></html>'
-        );
+        if (function_exists('mb_convert_encoding')) {
+            $document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', $encoding));
+        } else {
+            $this->addLog(
+                TransformerLog::DEBUG,
+                'Your content encoding is "' . $encoding . '" ' .
+                'but your PHP environment does not have mbstring. Trying to load your content with using meta tags.'
+            );
+            // wrap the content with charset meta tags
+            $document->loadHTML(
+                '<html><head>' .
+                '<meta http-equiv="Content-Type" content="text/html; charset=' . $encoding . '">' .
+                '</head><body>' . $content . '</body></html>'
+            );
+        }
         libxml_clear_errors();
         libxml_use_internal_errors($libxml_previous_state);
         $result = $this->transform($context, $document);


### PR DESCRIPTION
This PR reverts a previous change that broke transformations (#3) in one commit and applies a new fix in another commit that keeps the transformation working while addressing the PHP 8.2 deprecation notice that the original was meant to address.

See https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html for the background.