### PR TITLE
Move the dev dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^5.6 || ^7 || ^8",
+        "php": ">=5.4",
         "symfony/css-selector": "^2.8 || ^3.1 || ^4.1",
-        "facebook/graph-sdk": "dev-php8",
-        "phpcompatibility/phpcompatibility-wp": "^2.1"
+        "facebook/graph-sdk": "dev-php8"
     },
     "require-dev": {
         "fzaninotto/faker": "dev-master",
         "phpunit/phpunit": "4.8.*",
         "symfony/yaml": "2.1.* || 3.4.*",
         "phpdocumentor/reflection-docblock": "^2.0 || ^4.0",
-        "squizlabs/php_codesniffer": "^2.6.0 || ^3.0.0"
+        "squizlabs/php_codesniffer": "^2.6.0 || ^3.0.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With it in `require`, any consuming package running `composer i --no-dev` will still get all of the PHPCS-related packages installed.