### PR TITLE
Fully revert the encoding change

### DIFF
--- a/src/Facebook/InstantArticles/Transformer/Transformer.php
+++ b/src/Facebook/InstantArticles/Transformer/Transformer.php
@@ -246,7 +246,7 @@ class Transformer
         $libxml_previous_state = libxml_use_internal_errors(true);
         $document = new \DOMDocument('1.0');
         if (function_exists('mb_convert_encoding')) {
-            $document->loadHTML(htmlspecialchars_decode(htmlentities(mb_convert_encoding($content, 'UTF-8', $encoding), ENT_NOQUOTES)));
+	        $document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', $encoding));
         } else {
             $this->addLog(
                 TransformerLog::DEBUG,

--- a/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/TransformerTest.php
@@ -50,11 +50,11 @@ class TransformerTest extends BaseHTMLTestCase
         $transformer = new Transformer();
         $transformer->loadRules($json_file);
 
-        $title_html_string = '<h1>Test:あÖÄÜöäü</h1>';
+        $title_html_string = '<h1>Test:&あÖÄÜöäü唐আ</h1>';
         $header = Header::create();
         $transformer->transformString($header, $title_html_string);
 
-        $this->assertEqualsHtml('<h1>Test:あÖÄÜöäü</h1>', $header->getTitle()->render());
+        $this->assertEqualsHtml('<h1>Test:&amp;あÖÄÜöäü唐আ</h1>', $header->getTitle()->render());
     }
 
     public function testTransformStringWithMultibyteNonUTF8Content()


### PR DESCRIPTION
Reverts the code that encodes the content - reintroduces the code that produces a deprecation notice at PHP 8.2, but this plugin will be dead before most folks are using that.